### PR TITLE
Fix latest lockscreens being overwritten by older dates

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -99,21 +99,6 @@ jobs:
         run: |
           python generate.py ${{ steps.params.outputs.mosque }} ${{ steps.params.outputs.date }} --template ${{ steps.params.outputs.template }}
 
-      - name: Copy to 'latest' folder for stable URLs
-        if: steps.check.outputs.skip == 'false'
-        run: |
-          mkdir -p latest
-          for f in output/ramadan_lockscreen_*.png; do
-            base=$(basename "$f" .png)
-            # Remove prefix and date suffix, keep slug + optional _light
-            inner=${base#ramadan_lockscreen_}
-            # Last segment is the date (e.g., 18feb) — remove it
-            latest_name="ramadan_lockscreen_${inner%_*}_latest.png"
-            cp "$f" "latest/$latest_name"
-          done
-          echo "📁 Latest folder:"
-          ls -la latest/
-
       - name: Commit and push
         if: steps.check.outputs.skip == 'false'
         run: |


### PR DESCRIPTION
The workflow's "Copy to 'latest' folder" shell step iterated over ALL
files in output/ using a glob. Since bash globs expand alphabetically,
March dates (01mar) sorted before February dates (18feb-28feb), causing
February files to overwrite the correctly-copied March files.

generate.py already has a correct copy_to_latest() function that only
copies the files it just generated, so the redundant (and buggy)
workflow step is removed.

https://claude.ai/code/session_01TjQMtJd2gqCjbhFqDiEG1q