### PR TITLE
Add More hub tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -1436,6 +1436,71 @@
       margin-left: 4px;
     }
     .btn .beta-badge, .update-btn .beta-badge, .cta-btn .beta-badge { top: -1px; border: none; }
+
+    /* "More" hub grid */
+    .more-view { max-width: 720px; margin: 0 auto; }
+    .more-header { margin-bottom: 24px; }
+    .more-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 12px;
+    }
+    @media (min-width: 560px) {
+      .more-grid { grid-template-columns: repeat(3, 1fr); }
+    }
+    .more-tile {
+      display: flex; flex-direction: column; align-items: center; text-align: center;
+      gap: 8px; padding: 20px 14px;
+      background: var(--card-bg); border: 1px solid var(--card-border);
+      border-radius: 16px; backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);
+      text-decoration: none; color: var(--text-primary);
+      transition: background 0.2s, border-color 0.2s, transform 0.1s;
+      -webkit-tap-highlight-color: transparent;
+    }
+    .more-tile:hover { border-color: var(--gold-tint-40); background: var(--card-hover-bg); }
+    .more-tile:active { transform: scale(0.97); }
+    .more-tile-icon {
+      display: flex; align-items: center; justify-content: center;
+      width: 48px; height: 48px; border-radius: 14px;
+      background: var(--gold-tint-10); border: 1px solid var(--gold-tint-15);
+      color: var(--gold);
+    }
+    .more-tile-icon svg { width: 26px; height: 26px; }
+    .more-tile-label {
+      font-size: 0.95rem; font-weight: 700; color: var(--text-primary); line-height: 1.2;
+    }
+    .more-tile-desc {
+      font-size: 0.75rem; color: var(--text-muted); line-height: 1.35;
+    }
+    .more-tile-badge { top: 0; }
+    .more-tile-disabled {
+      opacity: 0.5; cursor: default;
+    }
+    .more-tile-disabled:hover { border-color: var(--card-border); background: var(--card-bg); }
+    .more-tile-disabled:active { transform: none; }
+
+    /* "Qibla moved to More" one-time hint toast */
+    .more-hint-toast {
+      position: fixed; bottom: calc(72px + env(safe-area-inset-bottom, 0px));
+      left: 50%; transform: translateX(-50%) translateY(20px);
+      display: flex; align-items: center; gap: 8px;
+      background: var(--card-bg); border: 1px solid var(--gold-tint-40);
+      backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);
+      color: var(--text-primary);
+      padding: 10px 12px 10px 16px; border-radius: 12px; font-size: 0.85rem; font-weight: 500;
+      z-index: 300; opacity: 0; cursor: pointer; max-width: calc(100vw - 32px);
+      transition: opacity 0.3s ease, transform 0.3s ease;
+      box-shadow: 0 6px 24px rgba(0,0,0,0.25);
+    }
+    .more-hint-toast.visible { opacity: 1; transform: translateX(-50%) translateY(0); }
+    .more-hint-toast .toast-star { color: var(--gold); }
+    .more-hint-toast .more-hint-close {
+      background: none; border: none; color: var(--text-muted);
+      font-size: 1.2rem; line-height: 1; cursor: pointer; padding: 0 2px;
+      font-family: inherit;
+    }
+    .more-hint-toast .more-hint-close:hover { color: var(--text-primary); }
+
     .pending-notice {
       text-align: center;
       padding: 10px 16px;
@@ -2153,6 +2218,7 @@
         <a href="/" class="desktop-nav-link" data-nav="home" data-link>Home</a>
         <a href="/eid" class="desktop-nav-link" data-nav="eid-times" data-link id="desktopEidLink" style="display:none">Eid Salah</a>
         <a href="/add" class="desktop-nav-link" data-nav="add-masjid" data-link>Add Masjid</a>
+        <a href="/more" class="desktop-nav-link" data-nav="more" data-link>More</a>
         <a href="/settings" class="desktop-nav-link" data-nav="settings" data-link>Settings</a>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -1449,6 +1449,7 @@
       .more-grid { grid-template-columns: repeat(3, 1fr); }
     }
     .more-tile {
+      position: relative;
       display: flex; flex-direction: column; align-items: center; text-align: center;
       gap: 8px; padding: 20px 14px;
       background: var(--card-bg); border: 1px solid var(--card-border);
@@ -1472,7 +1473,7 @@
     .more-tile-desc {
       font-size: 0.75rem; color: var(--text-muted); line-height: 1.35;
     }
-    .more-tile-badge { top: 0; margin-left: 0; }
+    .more-tile-badge { position: absolute; top: 8px; right: 8px; margin: 0; }
     .more-tile-disabled {
       opacity: 0.5; cursor: default;
     }

--- a/index.html
+++ b/index.html
@@ -1482,18 +1482,19 @@
     /* "Qibla moved to More" one-time hint toast */
     .more-hint-toast {
       position: fixed; bottom: calc(72px + env(safe-area-inset-bottom, 0px));
-      left: 50%; transform: translateX(-50%) translateY(20px);
+      left: 12px; right: 12px; transform: translateY(20px);
       display: flex; align-items: center; gap: 8px;
       background: var(--card-bg); border: 1px solid var(--gold-tint-40);
       backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);
       color: var(--text-primary);
       padding: 10px 12px 10px 16px; border-radius: 12px; font-size: 0.85rem; font-weight: 500;
-      z-index: 300; opacity: 0; cursor: pointer; max-width: calc(100vw - 32px);
+      z-index: 300; opacity: 0; cursor: pointer;
       transition: opacity 0.3s ease, transform 0.3s ease;
       box-shadow: 0 6px 24px rgba(0,0,0,0.25);
     }
-    .more-hint-toast.visible { opacity: 1; transform: translateX(-50%) translateY(0); }
+    .more-hint-toast.visible { opacity: 1; transform: translateY(0); }
     .more-hint-toast .toast-star { color: var(--gold); }
+    .more-hint-toast .more-hint-text { flex: 1; }
     .more-hint-toast .more-hint-close {
       background: none; border: none; color: var(--text-muted);
       font-size: 1.2rem; line-height: 1; cursor: pointer; padding: 0 2px;

--- a/index.html
+++ b/index.html
@@ -1472,7 +1472,7 @@
     .more-tile-desc {
       font-size: 0.75rem; color: var(--text-muted); line-height: 1.35;
     }
-    .more-tile-badge { top: 0; }
+    .more-tile-badge { top: 0; margin-left: 0; }
     .more-tile-disabled {
       opacity: 0.5; cursor: default;
     }

--- a/index.html
+++ b/index.html
@@ -1451,7 +1451,7 @@
     .more-tile {
       position: relative;
       display: flex; flex-direction: column; align-items: center; text-align: center;
-      gap: 8px; padding: 20px 14px;
+      gap: 6px; padding: 14px 12px;
       background: var(--card-bg); border: 1px solid var(--card-border);
       border-radius: 16px; backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);
       text-decoration: none; color: var(--text-primary);

--- a/js/app.js
+++ b/js/app.js
@@ -18,6 +18,7 @@ async function loadView(viewName) {
     'home': () => import('./views/home.js'),
     'masjids': () => import('./views/masjids.js'),
     'prayer-times': () => import('./views/prayer-times.js'),
+    'more': () => import('./views/more.js'),
     'qibla': () => import('./views/qibla.js'),
     'settings': () => import('./views/settings.js'),
     'add-masjid': () => import('./views/add-masjid.js'),

--- a/js/features.js
+++ b/js/features.js
@@ -20,7 +20,7 @@ export const FEATURES = [
   {
     id: 'qibla',
     label: 'Qibla',
-    desc: 'Find the direction of the Kaaba',
+    desc: 'Direction of the Kaaba',
     icon: QIBLA_SVG,
     route: '/qibla',
     badge: null,

--- a/js/features.js
+++ b/js/features.js
@@ -1,0 +1,70 @@
+// Feature registry — the single source of truth for the "More" hub grid.
+// Add a feature = add one object here (plus its own route in router.js / app.js).
+// Fields: { id, label, desc, icon, route, badge, enabled, show }
+//   badge   — null | 'NEW' | 'BETA' | 'SOON'  (small corner chip)
+//   enabled — false renders a dimmed, non-navigating tile (use with badge:'SOON')
+//   show()  — optional runtime predicate; falsy hides the tile entirely. Default shown.
+// Ordering = array order (worship-y first, utilities after, coming-soon last).
+
+const QIBLA_SVG = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polygon points="16.24 7.76 14.12 14.12 7.76 16.24 9.88 9.88 16.24 7.76"/></svg>';
+
+const EID_SVG = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2c-.4.6-.8 1.3-.6 2 .1.4.6.6.6.6s.5-.2.6-.6c.2-.7-.2-1.4-.6-2z"/><path d="M12 4.5C9.5 6.5 7 9 7 11.5c0 0 0 .5.2.5H16.8c.2 0 .2-.5.2-.5 0-2.5-2.5-5-5-7z"/><rect x="5" y="12" width="14" height="9"/><path d="M12 21v-5a2.5 2.5 0 0 0-2.5-2.5h0A2.5 2.5 0 0 0 7 16v5"/><rect x="2" y="10" width="3" height="11" rx=".5"/><rect x="19" y="10" width="3" height="11" rx=".5"/></svg>';
+
+const PLUS_SVG = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="16"/><line x1="8" y1="12" x2="16" y2="12"/></svg>';
+
+const CHECK_SVG = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>';
+
+const BEADS_SVG = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="5" cy="6" r="2"/><circle cx="12" cy="4" r="2"/><circle cx="19" cy="6" r="2"/><circle cx="20" cy="13" r="2"/><circle cx="12" cy="20" r="2"/><circle cx="4" cy="13" r="2"/><path d="M6.5 7.2 10.3 4.8M13.7 4.8l3.8 2.4M19.7 8l.5 3M18.4 14.4 13.6 18.7M10.4 18.7 5.6 14.4M4.3 11 4.8 8"/></svg>';
+
+export const FEATURES = [
+  {
+    id: 'qibla',
+    label: 'Qibla',
+    desc: 'Find the direction of the Kaaba',
+    icon: QIBLA_SVG,
+    route: '/qibla',
+    badge: null,
+    enabled: true,
+    show: () => true,
+  },
+  {
+    id: 'eid',
+    label: 'Eid Salah',
+    desc: 'All masjids by earliest jama\'at',
+    icon: EID_SVG,
+    route: '/eid',
+    badge: null,
+    enabled: true,
+    show: () => true,
+  },
+  {
+    id: 'add',
+    label: 'Add Masjid',
+    desc: 'Upload a timetable',
+    icon: PLUS_SVG,
+    route: '/add',
+    badge: 'BETA',
+    enabled: true,
+    show: () => true,
+  },
+  {
+    id: 'tracker',
+    label: 'Prayer Tracker',
+    desc: 'Coming soon',
+    icon: CHECK_SVG,
+    route: '/tracker',
+    badge: 'SOON',
+    enabled: false,
+    show: () => true,
+  },
+  {
+    id: 'tasbih',
+    label: 'Tasbih',
+    desc: 'Coming soon',
+    icon: BEADS_SVG,
+    route: '/tasbih',
+    badge: 'SOON',
+    enabled: false,
+    show: () => true,
+  },
+];

--- a/js/features.js
+++ b/js/features.js
@@ -35,7 +35,7 @@ export const FEATURES = [
     route: '/eid',
     badge: null,
     enabled: true,
-    show: () => true,
+    show: () => false, // hidden for now — re-enable when Eid masjids are ready
   },
   {
     id: 'add',

--- a/js/features.js
+++ b/js/features.js
@@ -53,7 +53,7 @@ export const FEATURES = [
     desc: 'Coming soon',
     icon: CHECK_SVG,
     route: '/tracker',
-    badge: 'SOON',
+    badge: null, // "Coming soon" desc already conveys this
     enabled: false,
     show: () => true,
   },
@@ -63,7 +63,7 @@ export const FEATURES = [
     desc: 'Coming soon',
     icon: BEADS_SVG,
     route: '/tasbih',
-    badge: 'SOON',
+    badge: null, // "Coming soon" desc already conveys this
     enabled: false,
     show: () => true,
   },

--- a/js/nav.js
+++ b/js/nav.js
@@ -21,10 +21,10 @@ const TABS = [
     icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>',
   },
   {
-    id: 'qibla',
-    label: 'Qibla',
-    path: '/qibla',
-    icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polygon points="16.24 7.76 14.12 14.12 7.76 16.24 9.88 9.88 16.24 7.76"/></svg>',
+    id: 'more',
+    label: 'More',
+    path: '/more',
+    icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/></svg>',
   },
   {
     id: 'settings',
@@ -39,10 +39,46 @@ function getTimesPath() {
   return pinned ? '/' + pinned : '/times';
 }
 
+// Views that live under the More hub all highlight the More tab.
+const MORE_HOSTED = new Set(['more', 'qibla', 'tracker', 'tasbih', 'dua', 'jummah-times']);
+
 function getActiveTabId() {
   const route = getCurrentRoute();
   if (route.view === 'add-masjid') return 'settings';
+  if (MORE_HOSTED.has(route.view)) return 'more';
   return route.view;
+}
+
+// One-time "Qibla moved to More" hint for existing users (mobile bottom nav only).
+function maybeShowMoreHint() {
+  if (localStorage.getItem('iqamah-more-hint')) return;
+  if (window.matchMedia('(min-width: 768px)').matches) return; // bottom nav is mobile-only
+
+  const dismiss = () => {
+    localStorage.setItem('iqamah-more-hint', '1');
+    toast.classList.remove('visible');
+    setTimeout(() => toast.remove(), 300);
+  };
+
+  const toast = document.createElement('div');
+  toast.className = 'more-hint-toast';
+  toast.innerHTML = `
+    <span class="toast-star">★</span>
+    <span class="more-hint-text">Qibla is now under <strong>More</strong></span>
+    <button class="more-hint-close" aria-label="Dismiss">&times;</button>`;
+  document.body.appendChild(toast);
+
+  toast.querySelector('.more-hint-close').addEventListener('click', (e) => {
+    e.stopPropagation();
+    dismiss();
+  });
+  toast.addEventListener('click', () => {
+    dismiss();
+    navigate('/more');
+  });
+
+  requestAnimationFrame(() => toast.classList.add('visible'));
+  setTimeout(() => { if (toast.isConnected) dismiss(); }, 7000);
 }
 
 export function initNav() {
@@ -50,6 +86,8 @@ export function initNav() {
   if (!nav) return;
 
   renderNav(nav);
+
+  maybeShowMoreHint();
 
   // Show desktop Eid link if season is eid
   fetch('/data/season.json').then(r => r.ok ? r.json() : null).then(s => {
@@ -109,6 +147,6 @@ export function updateActiveTab() {
   const activeView = route.view;
   desktopLinks.querySelectorAll('.desktop-nav-link').forEach(link => {
     const navId = link.dataset.nav;
-    link.classList.toggle('active', navId === activeView || (navId === 'masjids' && activeView === 'prayer-times') || (navId === 'eid-times' && activeView === 'eid-times'));
+    link.classList.toggle('active', navId === activeView || (navId === 'masjids' && activeView === 'prayer-times') || (navId === 'eid-times' && activeView === 'eid-times') || (navId === 'more' && MORE_HOSTED.has(activeView)));
   });
 }

--- a/js/router.js
+++ b/js/router.js
@@ -3,12 +3,19 @@
 let renderCallback = null;
 let currentPath = null;
 
-// Tab indices for slide direction
+// Tab indices for slide direction.
+// The More hub lives at index 3; every More-hosted view shares that index so
+// slide direction stays sane when navigating between the hub and its features.
 const TAB_INDEX = {
   home: 0,
   masjids: 1,
   'prayer-times': 2,
+  more: 3,
   qibla: 3,
+  tracker: 3,
+  tasbih: 3,
+  dua: 3,
+  'jummah-times': 3,
   settings: 4,
 };
 
@@ -24,6 +31,9 @@ export function resolvePath(path) {
   }
   if (clean === 'masjids') {
     return { view: 'masjids', params: {} };
+  }
+  if (clean === 'more') {
+    return { view: 'more', params: {} };
   }
   if (clean === 'qibla') {
     return { view: 'qibla', params: {} };

--- a/js/views/more.js
+++ b/js/views/more.js
@@ -18,7 +18,8 @@ function tileHTML(f) {
        data-enabled="${f.enabled ? '1' : '0'}"
        ${disabled ? 'aria-disabled="true"' : 'data-link'}>
       <span class="more-tile-icon">${f.icon}</span>
-      <span class="more-tile-label">${f.label}${badge}</span>
+      <span class="more-tile-label">${f.label}</span>
+      ${badge}
       ${desc}
     </a>`;
 }

--- a/js/views/more.js
+++ b/js/views/more.js
@@ -1,0 +1,54 @@
+// "More" hub view — a grid of feature tiles driven by the FEATURES registry.
+import { FEATURES } from '../features.js';
+import { navigate } from '../router.js';
+
+let clickHandler = null;
+
+function tileHTML(f) {
+  const disabled = !f.enabled;
+  const badge = f.badge
+    ? `<span class="beta-badge more-tile-badge">${f.badge}</span>`
+    : '';
+  const desc = f.desc ? `<span class="more-tile-desc">${f.desc}</span>` : '';
+
+  return `
+    <a class="more-tile${disabled ? ' more-tile-disabled' : ''}"
+       href="${disabled ? '#' : f.route}"
+       data-route="${f.route}"
+       data-enabled="${f.enabled ? '1' : '0'}"
+       ${disabled ? 'aria-disabled="true"' : 'data-link'}>
+      <span class="more-tile-icon">${f.icon}</span>
+      <span class="more-tile-label">${f.label}${badge}</span>
+      ${desc}
+    </a>`;
+}
+
+export function render(container) {
+  const tiles = FEATURES
+    .filter(f => (typeof f.show === 'function' ? f.show() : true))
+    .map(tileHTML)
+    .join('');
+
+  container.innerHTML = `
+    <div class="more-view">
+      <header class="more-header">
+        <h1>More</h1>
+      </header>
+      <div class="more-grid">
+        ${tiles}
+      </div>
+    </div>`;
+
+  clickHandler = (e) => {
+    const tile = e.target.closest('.more-tile');
+    if (!tile) return;
+    e.preventDefault();
+    if (tile.dataset.enabled !== '1') return; // SOON tiles don't navigate
+    navigate(tile.dataset.route);
+  };
+  container.querySelector('.more-grid').addEventListener('click', clickHandler);
+}
+
+export function destroy() {
+  clickHandler = null;
+}


### PR DESCRIPTION
Replaces the Qibla bottom-nav tab (index 3) with a More tab that opens a
responsive grid of feature tiles driven by a declarative registry
(js/features.js). Qibla keeps its /qibla route and becomes the first tile.

Launch tiles: Qibla, Eid Salah, Add Masjid (BETA), Prayer Tracker (SOON,
disabled), Tasbih (SOON, disabled). Disabled tiles are dimmed and
non-navigating.

- js/features.js: FEATURES registry (single source for tiles)
- js/views/more.js: renders the grid, honours enabled/show/badge
- js/nav.js: TABS qibla->more (grid icon); More-hosted views highlight
  More tab (bottom + desktop); one-time iqamah-more-hint relocation toast
- js/router.js: resolvePath /more; TAB_INDEX maps hosted views to 3
- js/app.js: moduleMap more -> views/more.js
- index.html: desktop More nav link + .more-* grid/tile/toast styles

/more already serves the SPA shell via the worker's single-segment rule.