### PR TITLE
Fairer API rate limiting: count only validated attempts, bucket IPv6 by /64

### DIFF
--- a/.github/workflows/worker-tests.yml
+++ b/.github/workflows/worker-tests.yml
@@ -1,0 +1,25 @@
+name: Worker Tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '_worker.js'
+      - 'tests/**'
+      - 'prompts/extraction.txt'
+  pull_request:
+    paths:
+      - '_worker.js'
+      - 'tests/**'
+      - 'prompts/extraction.txt'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Run worker API tests
+        run: node --test tests/worker.test.mjs

--- a/_worker.js
+++ b/_worker.js
@@ -12,33 +12,54 @@ function isAdminRequest(request, env) {
 }
 
 // --- Rate limiting (persistent via Cloudflare KV) ---
+// Two-phase: checkRateLimit() is a read-only gate at the top of a handler;
+// recordRateLimitUse() increments only after the request has passed validation
+// (Turnstile, form checks), so failed attempts don't silently burn quota.
 const RATE_LIMITS_CONFIG = {
-  extract: { max: 5, windowSecs: 30 * 24 * 60 * 60 }, // 5 per month
-  submit: { max: 5, windowSecs: 30 * 24 * 60 * 60 },  // 5 per month
-  update: { max: 5, windowSecs: 30 * 24 * 60 * 60 },  // 5 per month
+  extract: { max: 10, windowSecs: 30 * 24 * 60 * 60 }, // per rolling 30 days
+  submit: { max: 5, windowSecs: 30 * 24 * 60 * 60 },   // new masjids - keep tight
+  update: { max: 10, windowSecs: 30 * 24 * 60 * 60 },  // paired with extract
 };
 
-async function isRateLimited(ip, action, env, request) {
-  if (!env.RATE_LIMITS) return false;
-  if (isAdminRequest(request, env)) return false;
+// IPv6 devices rotate their full /128 address (privacy extensions), so bucket
+// by the /64 prefix - one bucket per connection, matching how a NAT'd IPv4
+// household already behaves. IPv4 (and 'unknown') pass through unchanged.
+function rateLimitBucket(ip) {
+  if (!ip || !ip.includes(':')) return ip;
+  const left = ip.split('::')[0].split(':').filter(Boolean);
+  while (left.length < 4) left.push('0');
+  return left.slice(0, 4).join(':') + '::/64';
+}
+
+// Returns null if allowed, or { resetsAt: Date } if the bucket is full.
+async function checkRateLimit(ip, action, env, request) {
+  if (!env.RATE_LIMITS) return null;
+  if (isAdminRequest(request, env)) return null;
   const config = RATE_LIMITS_CONFIG[action];
-  if (!config) return false;
-  const key = `${action}:${ip}`;
+  if (!config) return null;
+  const key = `${action}:${rateLimitBucket(ip)}`;
   const data = await env.RATE_LIMITS.get(key, 'json');
+  if (!data || data.count < config.max) return null;
+  return { resetsAt: new Date(data.start + config.windowSecs * 1000), max: config.max };
+}
+
+async function recordRateLimitUse(ip, action, env, request) {
+  if (!env.RATE_LIMITS) return;
+  if (isAdminRequest(request, env)) return;
+  const config = RATE_LIMITS_CONFIG[action];
+  if (!config) return;
+  const key = `${action}:${rateLimitBucket(ip)}`;
   const now = Date.now();
-
-  if (!data) {
-    await env.RATE_LIMITS.put(key, JSON.stringify({ count: 1, start: now }), { expirationTtl: config.windowSecs });
-    return false;
-  }
-
-  if (data.count >= config.max) return true;
-
+  const data = (await env.RATE_LIMITS.get(key, 'json')) || { count: 0, start: now };
   data.count++;
   const elapsed = Math.floor((now - data.start) / 1000);
   const remaining = Math.max(config.windowSecs - elapsed, 60);
   await env.RATE_LIMITS.put(key, JSON.stringify(data), { expirationTtl: remaining });
-  return false;
+}
+
+function rateLimitResponse(what, limited) {
+  const dateStr = limited.resetsAt.toLocaleDateString('en-GB', { day: 'numeric', month: 'long' });
+  return errorResponse(`You've reached the limit of ${limited.max} ${what} in 30 days on this connection. Please try again after ${dateStr}.`, 429);
 }
 
 // --- Turnstile verification ---
@@ -1071,10 +1092,11 @@ async function handleExtract(request, env) {
     return errorResponse('Server configuration error: missing API key', 500);
   }
 
-  // Rate limit
+  // Rate limit (read-only check; quota is consumed after validation passes)
   const ip = request.headers.get('CF-Connecting-IP') || 'unknown';
-  if (await isRateLimited(ip, 'extract', env, request)) {
-    return errorResponse('You\'ve reached the limit of 5 extractions per month. Please try again next month.', 429);
+  const extractLimited = await checkRateLimit(ip, 'extract', env, request);
+  if (extractLimited) {
+    return rateLimitResponse('extractions', extractLimited);
   }
 
   let formData;
@@ -1130,6 +1152,9 @@ async function handleExtract(request, env) {
     console.error('Failed to load extraction prompt:', e);
     return errorResponse('Server configuration error: missing extraction prompt', 500);
   }
+
+  // Validation passed - this attempt now counts against the quota
+  await recordRateLimitUse(ip, 'extract', env, request);
 
   // Call Claude API
   try {
@@ -1346,10 +1371,11 @@ async function handleSubmit(request, env) {
     return errorResponse('Server configuration error: missing GitHub token', 500);
   }
 
-  // Rate limit
+  // Rate limit (read-only check; quota is consumed after validation passes)
   const ip = request.headers.get('CF-Connecting-IP') || 'unknown';
-  if (await isRateLimited(ip, 'submit', env, request)) {
-    return errorResponse('You\'ve reached the limit of 5 submissions per month. Please try again next month.', 429);
+  const submitLimited = await checkRateLimit(ip, 'submit', env, request);
+  if (submitLimited) {
+    return rateLimitResponse('submissions', submitLimited);
   }
 
   let body;
@@ -1420,6 +1446,9 @@ async function handleSubmit(request, env) {
       }, 409);
     }
   }
+
+  // Validation passed - this attempt now counts against the quota
+  await recordRateLimitUse(ip, 'submit', env, request);
 
   // Generate slug
   let slug = data.suggested_slug || slugify(mosqueName);
@@ -1608,10 +1637,11 @@ async function handleUpdate(request, env) {
     return errorResponse('Server configuration error: missing GitHub token', 500);
   }
 
-  // Rate limit
+  // Rate limit (read-only check; quota is consumed after validation passes)
   const ip = request.headers.get('CF-Connecting-IP') || 'unknown';
-  if (await isRateLimited(ip, 'update', env, request)) {
-    return errorResponse('You\'ve reached the limit of 5 timetable updates per month. Please try again next month.', 429);
+  const updateLimited = await checkRateLimit(ip, 'update', env, request);
+  if (updateLimited) {
+    return rateLimitResponse('timetable updates', updateLimited);
   }
 
   let body;
@@ -1669,6 +1699,9 @@ async function handleUpdate(request, env) {
   if (dateError) {
     return errorResponse(dateError);
   }
+
+  // Validation passed - this attempt now counts against the quota
+  await recordRateLimitUse(ip, 'update', env, request);
 
   // Apply validation fixes on new rows
   const notes = data.notes || existingConfig.notes || '';

--- a/js/utils/pwa.js
+++ b/js/utils/pwa.js
@@ -6,6 +6,10 @@ export function registerServiceWorker() {
   if (!('serviceWorker' in navigator)) return;
 
   navigator.serviceWorker.register('/sw.js').then(registration => {
+    // Registration can be unavailable even when the API exists
+    // (private browsing modes, embedded webviews, test browsers)
+    if (!registration) return;
+
     // Check for updates every 30 minutes
     setInterval(() => registration.update(), 30 * 60 * 1000);
 
@@ -25,6 +29,8 @@ export function registerServiceWorker() {
         }
       });
     });
+  }).catch(e => {
+    console.warn('Service worker registration failed:', e);
   });
 
   // When a new SW takes control, reload for fresh content

--- a/tests/e2e/upload_flows.py
+++ b/tests/e2e/upload_flows.py
@@ -125,15 +125,9 @@ def stop_wrangler(proc):
             proc.kill()
 
 
-# The test context blocks service workers (so Playwright route interception
-# sees every request), which makes the SW registration in js/utils/pwa.js
-# reject with this error. Expected in tests only - not an app bug.
-SW_BLOCKED_ERROR = "reading 'waiting'"
-
-
 def setup_page(context, captured, errors):
     page = context.new_page()
-    page.on("pageerror", lambda e: errors.append(f"pageerror: {e}") if SW_BLOCKED_ERROR not in str(e) else None)
+    page.on("pageerror", lambda e: errors.append(f"pageerror: {e}"))
     page.on("console", lambda m: errors.append(f"console.error: {m.text}") if m.type == "error" else None)
 
     def turnstile_handler(route):

--- a/tests/e2e/upload_flows.py
+++ b/tests/e2e/upload_flows.py
@@ -1,0 +1,277 @@
+"""E2E browser tests for the Add Masjid and Update Masjid wizards.
+
+Drives the real SPA in Chromium against a local `wrangler pages dev` server,
+walking both upload wizards end to end: file upload -> extract -> review ->
+submit -> confirmation.
+
+External seams are stubbed IN THE BROWSER via Playwright route interception:
+  - /api/extract, /api/submit, /api/update return canned responses
+  - the Cloudflare Turnstile script is replaced with a stub that issues a token
+The worker side of those seams is covered by tests/worker.test.mjs, so between
+the two suites the full path is pinned: this suite proves the client sends the
+right payloads and renders every wizard step; the node suite proves the worker
+handles those payloads correctly.
+
+Usage:
+    python tests/e2e/upload_flows.py               # starts wrangler itself
+    python tests/e2e/upload_flows.py --headed      # watch the browser
+    python tests/e2e/upload_flows.py --base-url http://127.0.0.1:8788
+                                                   # reuse a running server
+
+Requires: playwright (+ chromium), pillow, wrangler (all existing project deps).
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from playwright.sync_api import expect, sync_playwright
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_PORT = 8788
+UPDATE_SLUG = "faizul"  # any masjid with a config in data/mosques/
+
+MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+DAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+
+TURNSTILE_STUB = """
+window.turnstile = {
+  render: function (sel, opts) {
+    if (opts && opts.callback) setTimeout(function () { opts.callback('e2e-token'); }, 30);
+    return 0;
+  },
+  reset: function () {},
+  remove: function () {}
+};
+if (window.onTurnstileLoad) window.onTurnstileLoad();
+"""
+
+
+def sample_extraction(name="Extracted Masjid Name"):
+    """Three rows starting tomorrow; times chosen to pass the client-side
+    validateExtractedData sanity checks."""
+    rows = []
+    year = datetime.now(timezone.utc).year
+    for i in range(1, 4):
+        d = datetime.now(timezone.utc) + timedelta(days=i)
+        year = d.year
+        rows.append({
+            "date": f"{d.day} {MONTHS[d.month - 1]}",
+            "day": DAYS[int(d.strftime('%w'))],
+            "islamic_day": None,
+            "sehri_ends": "", "fajr_start": "03:15", "sunrise": "04:45", "zawal": "",
+            "zohr": "01:18", "asr": "05:39", "esha": "",
+            "fajr_jamaat": "3:45", "zohar_jamaat": "1:30", "asr_jamaat": "6:00",
+            "maghrib_iftari": "09:44", "maghrib_jamaat": "", "esha_jamaat": "10:59",
+        })
+    return {
+        "mosque_name": name, "suggested_slug": "", "address": "", "phone": "",
+        "month": "E2E", "year": year, "islamic_month": "", "jummah_times": "",
+        "eid_salah": "", "sadaqatul_fitr": "", "radio_frequency": "", "notes": "",
+        "rows": rows,
+    }
+
+
+def make_fixture_image(path):
+    """A >=800px-per-side PNG so the client-side resolution check passes."""
+    from PIL import Image, ImageDraw
+    img = Image.new("RGB", (1000, 1400), "white")
+    d = ImageDraw.Draw(img)
+    d.text((40, 30), "E2E Test Timetable", fill="black")
+    for i in range(30):
+        d.text((40, 90 + i * 40), f"{i + 1} Aug   05:00  06:30  13:15  18:00  21:00", fill="black")
+    img.save(path)
+
+
+def wait_for_server(base_url, timeout=120):
+    deadline = time.time() + timeout
+    last_err = None
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(f"{base_url}/version.json", timeout=3) as r:
+                if r.status == 200:
+                    return
+        except Exception as e:  # noqa: BLE001 - retry until deadline
+            last_err = e
+        time.sleep(1)
+    raise RuntimeError(f"Dev server did not become ready at {base_url}: {last_err}")
+
+
+def start_wrangler(port, log_path):
+    log = open(log_path, "w", encoding="utf-8")
+    proc = subprocess.Popen(
+        f"npx wrangler pages dev . --port {port}",
+        cwd=ROOT, shell=True, stdout=log, stderr=subprocess.STDOUT,
+    )
+    return proc, log
+
+
+def stop_wrangler(proc):
+    if proc.poll() is not None:
+        return
+    if sys.platform == "win32":
+        subprocess.run(f"taskkill /PID {proc.pid} /T /F", shell=True, capture_output=True)
+    else:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+# The test context blocks service workers (so Playwright route interception
+# sees every request), which makes the SW registration in js/utils/pwa.js
+# reject with this error. Expected in tests only - not an app bug.
+SW_BLOCKED_ERROR = "reading 'waiting'"
+
+
+def setup_page(context, captured, errors):
+    page = context.new_page()
+    page.on("pageerror", lambda e: errors.append(f"pageerror: {e}") if SW_BLOCKED_ERROR not in str(e) else None)
+    page.on("console", lambda m: errors.append(f"console.error: {m.text}") if m.type == "error" else None)
+
+    def turnstile_handler(route):
+        if "api.js" in route.request.url:
+            route.fulfill(status=200, content_type="application/javascript", body=TURNSTILE_STUB)
+        else:
+            route.fulfill(status=200, body="")
+
+    page.route("**/challenges.cloudflare.com/**", turnstile_handler)
+
+    def extract_handler(route):
+        captured["extract_action"] = (route.request.post_data or "").count("name=\"action\"")
+        route.fulfill(json={"success": True, "data": sample_extraction()})
+
+    page.route("**/api/extract", extract_handler)
+
+    def submit_handler(route):
+        captured["submit"] = json.loads(route.request.post_data)
+        route.fulfill(json={
+            "success": True, "slug": "e2e_test_masjid", "url": "/e2e_test_masjid",
+            "pending": True, "message": "E2E Test Masjid has been submitted for review!",
+        })
+
+    page.route("**/api/submit", submit_handler)
+
+    def update_handler(route):
+        captured["update"] = json.loads(route.request.post_data)
+        route.fulfill(json={
+            "success": True, "slug": UPDATE_SLUG, "url": f"/{UPDATE_SLUG}",
+            "pending": True, "message": "Timetable has been updated!",
+        })
+
+    page.route("**/api/update", update_handler)
+    return page
+
+
+def walk_wizard(page, base_url, path, fixture, masjid_name=None):
+    """Shared steps: upload file -> extract -> review appears -> submit -> done."""
+    page.goto(f"{base_url}{path}")
+    page.wait_for_selector("#fileInput", state="attached", timeout=30000)
+    page.set_input_files("#fileInput", fixture)
+    expect(page.locator("#extractBtn")).to_be_enabled(timeout=15000)
+    page.click("#extractBtn")
+
+    page.wait_for_selector("#step3.active", timeout=20000)
+    expect(page.locator("#reviewTbody tr")).to_have_count(3)
+
+    if masjid_name is not None:
+        page.fill("#masjidName", masjid_name)
+
+    page.click("#submitBtn")
+    page.wait_for_selector("#step4.active", timeout=15000)
+    expect(page.locator("#confirmationText")).to_be_visible()
+
+
+def test_add_flow(context, base_url, fixture):
+    captured, errors = {}, []
+    page = setup_page(context, captured, errors)
+    walk_wizard(page, base_url, "/add", fixture, masjid_name="E2E Test Masjid")
+
+    payload = captured.get("submit")
+    assert payload, "submit was never called"
+    assert payload["data"]["mosque_name"] == "E2E Test Masjid", payload["data"].get("mosque_name")
+    assert len(payload["data"]["rows"]) == 3, f"expected 3 rows, got {len(payload['data']['rows'])}"
+    assert payload["data"]["rows"][0]["fajr_jamaat"], "review table lost the jama'at times"
+    assert payload.get("image", "").startswith("data:image/"), "source image missing from submit"
+    page.close()
+    return errors
+
+
+def test_update_flow(context, base_url, fixture):
+    captured, errors = {}, []
+    page = setup_page(context, captured, errors)
+    walk_wizard(page, base_url, f"/update/{UPDATE_SLUG}", fixture)
+
+    payload = captured.get("update")
+    assert payload, "update was never called"
+    assert payload["slug"] == UPDATE_SLUG, payload.get("slug")
+    assert len(payload["data"]["rows"]) == 3, f"expected 3 rows, got {len(payload['data']['rows'])}"
+    page.close()
+    return errors
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base-url", help="reuse a running dev server instead of starting wrangler")
+    ap.add_argument("--headed", action="store_true", help="run with a visible browser")
+    args = ap.parse_args()
+
+    tmpdir = Path(tempfile.mkdtemp(prefix="iqamah-e2e-"))
+    fixture = str(tmpdir / "timetable.png")
+    make_fixture_image(fixture)
+
+    proc = log = None
+    base_url = args.base_url
+    wrangler_log = tmpdir / "wrangler.log"
+    if not base_url:
+        base_url = f"http://127.0.0.1:{DEFAULT_PORT}"
+        print(f"Starting wrangler pages dev on {base_url} (log: {wrangler_log})")
+        proc, log = start_wrangler(DEFAULT_PORT, wrangler_log)
+    try:
+        wait_for_server(base_url)
+        version = json.loads((ROOT / "version.json").read_text(encoding="utf-8-sig"))
+        seed = (
+            f"localStorage.setItem('iqamah-review-hint-dismissed','1');"
+            f"localStorage.setItem('iqamah-last-seen-version','{version.get('version', '')}');"
+        )
+
+        failures = []
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=not args.headed)
+            context = browser.new_context(service_workers="block")
+            context.add_init_script(seed)
+
+            for name, fn in [("add masjid", test_add_flow), ("update masjid", test_update_flow)]:
+                try:
+                    errors = fn(context, base_url, fixture)
+                    js_errors = [e for e in errors if e.startswith("pageerror")]
+                    if js_errors:
+                        raise AssertionError("uncaught JS errors: " + "; ".join(js_errors[:3]))
+                    print(f"PASS  {name}")
+                except Exception as e:  # noqa: BLE001 - report and continue
+                    print(f"FAIL  {name}: {e}")
+                    failures.append(name)
+            browser.close()
+
+        if failures:
+            print(f"\n{len(failures)} flow(s) failed: {', '.join(failures)}")
+            if proc and wrangler_log.exists():
+                print(f"wrangler log: {wrangler_log}")
+            sys.exit(1)
+        print("\nAll browser flows passed.")
+    finally:
+        if proc:
+            stop_wrangler(proc)
+        if log:
+            log.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/worker.test.mjs
+++ b/tests/worker.test.mjs
@@ -1,0 +1,383 @@
+// ============================================================
+// Worker API tests — the self-service upload flow
+//
+// Run with:  node --test tests/
+// (no dependencies — uses Node's built-in test runner, Node 18+)
+//
+// These call the real _worker.js fetch handler with a fake env:
+// in-memory KV, an ASSETS stub serving prompts/extraction.txt from
+// disk, and a stubbed global fetch for GitHub / Claude / Turnstile /
+// Nominatim. Run them after ANY change to _worker.js — they cover
+// the /api/extract, /api/submit and /api/update paths end to end.
+// ============================================================
+
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import worker from '../_worker.js';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const EXTRACTION_PROMPT = readFileSync(join(ROOT, 'prompts', 'extraction.txt'), 'utf8');
+
+// --- Fakes ---------------------------------------------------
+
+class FakeKV {
+  constructor() { this.store = new Map(); }
+  async get(key, type) {
+    const v = this.store.get(key);
+    if (v === undefined) return null;
+    return type === 'json' ? JSON.parse(v) : v;
+  }
+  async put(key, value, _opts) { this.store.set(key, String(value)); }
+  async delete(key) { this.store.delete(key); }
+  seed(key, obj) { this.store.set(key, JSON.stringify(obj)); }
+  json(key) { const v = this.store.get(key); return v === undefined ? null : JSON.parse(v); }
+}
+
+function makeEnv(overrides = {}) {
+  return {
+    ANTHROPIC_API_KEY: 'test-anthropic-key',
+    GITHUB_PAT: 'test-pat',
+    ADMIN_NAME: 'AdminUser',
+    RATE_LIMITS: new FakeKV(),
+    ASSETS: {
+      fetch: async (input) => {
+        const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+        const path = new URL(url).pathname;
+        if (path === '/prompts/extraction.txt') return new Response(EXTRACTION_PROMPT);
+        return new Response('Not found', { status: 404 });
+      },
+    },
+    ...overrides,
+  };
+}
+
+const j = (obj, status = 200) =>
+  new Response(JSON.stringify(obj), { status, headers: { 'Content-Type': 'application/json' } });
+
+// Recorded outbound calls for assertions: [{ method, url, body }]
+let fetchCalls = [];
+
+// Install a fetch stub. `overrides` maps a URL substring to a handler
+// ({ url, method, body }) => Response; unmatched URLs hit sane defaults.
+function installFetch(overrides = {}) {
+  fetchCalls = [];
+  globalThis.fetch = async (input, init = {}) => {
+    const url = typeof input === 'string' ? input : input.url;
+    const method = (init.method || 'GET').toUpperCase();
+    const body = typeof init.body === 'string' ? init.body : null;
+    fetchCalls.push({ url, method, body });
+    for (const [substr, handler] of Object.entries(overrides)) {
+      if (url.includes(substr)) return handler({ url, method, body });
+    }
+    return defaultRoutes({ url, method, body });
+  };
+}
+
+function sampleExtraction() {
+  const { rows, year } = sampleRows();
+  return {
+    mosque_name: 'Extracted Masjid Name',
+    suggested_slug: '',
+    address: '', phone: '', month: 'Test', year,
+    islamic_month: '', jummah_times: '', eid_salah: '',
+    sadaqatul_fitr: '', radio_frequency: '', notes: '',
+    rows,
+  };
+}
+
+function defaultRoutes({ url, method }) {
+  if (url.includes('challenges.cloudflare.com')) return j({ success: true });
+  if (url.includes('api.anthropic.com')) {
+    return j({ content: [{ text: JSON.stringify(sampleExtraction()) }] });
+  }
+  if (url.includes('nominatim.openstreetmap.org')) return j([]);
+  if (url.includes('api.github.com')) {
+    if (url.endsWith('/git/ref/heads/main')) return j({ object: { sha: 'headsha' } });
+    if (url.includes('/git/commits/headsha')) return j({ sha: 'headsha', tree: { sha: 'basetree' } });
+    if (url.endsWith('/git/blobs')) return j({ sha: 'blobsha' });
+    if (url.endsWith('/git/trees')) return j({ sha: 'newtree' });
+    if (url.endsWith('/git/commits')) return j({ sha: 'newcommit' });
+    if (url.includes('/git/refs/heads/main')) return j({ ok: true });
+    if (url.endsWith('/issues')) return j({ number: 1 }, 201);
+    if (url.includes('/dispatches')) return new Response(null, { status: 204 });
+    if (method === 'PUT' && url.includes('/contents/')) return j({ content: {} }, 201);
+    // Directory listing used by deduplicateSlug
+    if (url.endsWith('/contents/data/mosques')) return j([]);
+    if (url.includes('/contents/')) return new Response('Not Found', { status: 404 });
+  }
+  throw new Error(`Unexpected outbound fetch in test: ${method} ${url}`);
+}
+
+// --- Test data -----------------------------------------------
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+const DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+// Three rows starting tomorrow, so date validation always passes.
+function sampleRows() {
+  const rows = [];
+  let year = new Date().getUTCFullYear();
+  for (let i = 1; i <= 3; i++) {
+    const d = new Date(Date.now() + i * 86400000);
+    year = d.getUTCFullYear();
+    rows.push({
+      date: `${d.getUTCDate()} ${MONTHS[d.getUTCMonth()]}`,
+      day: DAYS[d.getUTCDay()],
+      islamic_day: null,
+      sehri_ends: '', fajr_start: '03:15', sunrise: '04:45', zawal: '',
+      zohr: '01:18', asr: '05:39', esha: '',
+      fajr_jamaat: '3:45', zohar_jamaat: '1:30', asr_jamaat: '6:00',
+      maghrib_iftari: '09:44', maghrib_jamaat: '', esha_jamaat: '10:59',
+    });
+  }
+  return { rows, year };
+}
+
+function pastRows() {
+  return {
+    rows: [{
+      date: '1 Jan', day: 'Thu', islamic_day: null,
+      sehri_ends: '', fajr_start: '06:15', sunrise: '08:15', zawal: '',
+      zohr: '12:10', asr: '02:00', esha: '',
+      fajr_jamaat: '6:45', zohar_jamaat: '12:30', asr_jamaat: '2:30',
+      maghrib_iftari: '04:05', maghrib_jamaat: '', esha_jamaat: '07:00',
+    }],
+    year: 2020,
+  };
+}
+
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+function extractRequest({ ip = '1.2.3.4', name = 'Test Masjid', withFile = true, headers = {} } = {}) {
+  const fd = new FormData();
+  if (withFile) fd.append('image', new File([PNG_BYTES], 'timetable.png', { type: 'image/png' }));
+  if (name) fd.append('name', name);
+  return new Request('https://iqamah.co.uk/api/extract', {
+    method: 'POST', body: fd,
+    headers: { 'CF-Connecting-IP': ip, ...headers },
+  });
+}
+
+function submitRequest(body, { ip = '1.2.3.4', headers = {} } = {}) {
+  return new Request('https://iqamah.co.uk/api/submit', {
+    method: 'POST', body: JSON.stringify(body),
+    headers: { 'CF-Connecting-IP': ip, 'Content-Type': 'application/json', ...headers },
+  });
+}
+
+function updateRequest(body, { ip = '1.2.3.4', headers = {} } = {}) {
+  return new Request('https://iqamah.co.uk/api/update', {
+    method: 'POST', body: JSON.stringify(body),
+    headers: { 'CF-Connecting-IP': ip, 'Content-Type': 'application/json', ...headers },
+  });
+}
+
+// Existing masjid fixture for update tests
+const EXISTING_CONFIG = { display_name: 'Test Masjid', slug: 'testmasjid', csv: 'testmasjid.csv' };
+const EXISTING_CSV = [
+  "Date,Day,Islamic Day,Sehri Ends,Fajr Start,Sunrise,Zawal,Zohr,Asr,Esha,Fajr Jama'at,Zohar Jama'at,Asr Jama'at,Maghrib Iftari,Maghrib Jama'at,Esha Jama'at",
+  '1 Jan,Thu,,,06:15,08:15,,12:10,02:00,,6:45,12:30,2:30,04:05,,07:00',
+].join('\n');
+
+function updateOverrides() {
+  return {
+    'contents/data/mosques/testmasjid.json': () =>
+      j({ content: btoa(JSON.stringify(EXISTING_CONFIG)), sha: 'cfgsha' }),
+    'contents/data/testmasjid.csv': () =>
+      j({ content: btoa(EXISTING_CSV), sha: 'csvsha' }),
+    'contents/data/mosques/index.json': () =>
+      j({ content: btoa(JSON.stringify([EXISTING_CONFIG])), sha: 'idxsha' }),
+  };
+}
+
+// --- Tests ---------------------------------------------------
+
+let env;
+beforeEach(() => {
+  env = makeEnv();
+  installFetch();
+});
+
+// ---- /api/extract: rate limiting ----
+
+test('extract: full bucket returns 429 with the real limit and a reset date', async () => {
+  const start = Date.now() - 5 * 86400000;
+  env.RATE_LIMITS.seed('extract:1.2.3.4', { count: 10, start });
+  const res = await worker.fetch(extractRequest(), env);
+  assert.equal(res.status, 429);
+  const body = await res.json();
+  assert.match(body.error, /limit of 10 extractions/);
+  assert.match(body.error, /try again after/i);
+  // Quota not incremented further while blocked
+  assert.equal(env.RATE_LIMITS.json('extract:1.2.3.4').count, 10);
+});
+
+test('extract: request below the limit is allowed through', async () => {
+  env.RATE_LIMITS.seed('extract:1.2.3.4', { count: 9, start: Date.now() - 86400000 });
+  const res = await worker.fetch(extractRequest(), env);
+  assert.equal(res.status, 200);
+  assert.equal(env.RATE_LIMITS.json('extract:1.2.3.4').count, 10);
+});
+
+test('extract: a failed request (no file) does NOT consume quota', async () => {
+  const res = await worker.fetch(extractRequest({ withFile: false }), env);
+  assert.equal(res.status, 400);
+  assert.equal(env.RATE_LIMITS.store.size, 0);
+});
+
+test('extract: a failed Turnstile check does NOT consume quota', async () => {
+  env.TURNSTILE_SECRET = 'secret';
+  // No cf-turnstile-response token in the form -> verification fails
+  const res = await worker.fetch(extractRequest(), env);
+  assert.equal(res.status, 403);
+  assert.equal(env.RATE_LIMITS.store.size, 0);
+});
+
+test('extract: a successful extraction consumes exactly one', async () => {
+  const res = await worker.fetch(extractRequest(), env);
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.success, true);
+  assert.equal(env.RATE_LIMITS.json('extract:1.2.3.4').count, 1);
+});
+
+test('extract: IPv6 addresses in the same /64 share one bucket', async () => {
+  await worker.fetch(extractRequest({ ip: '2a04:4a43:883f:f41b:aaaa:1:2:3' }), env);
+  await worker.fetch(extractRequest({ ip: '2a04:4a43:883f:f41b:bbbb:4:5:6' }), env);
+  const bucket = env.RATE_LIMITS.json('extract:2a04:4a43:883f:f41b::/64');
+  assert.ok(bucket, 'expected a /64-keyed bucket');
+  assert.equal(bucket.count, 2);
+  assert.equal(env.RATE_LIMITS.store.size, 1);
+});
+
+test('extract: admin header bypasses a full bucket', async () => {
+  env.RATE_LIMITS.seed('extract:1.2.3.4', { count: 10, start: Date.now() });
+  const res = await worker.fetch(extractRequest({ headers: { 'X-User-Name': 'AdminUser' } }), env);
+  assert.equal(res.status, 200);
+});
+
+// ---- /api/extract: extraction behaviour ----
+
+test('extract: happy path returns extracted rows and applies the name override', async () => {
+  const res = await worker.fetch(extractRequest({ name: 'My Real Masjid' }), env);
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.success, true);
+  assert.equal(body.data.mosque_name, 'My Real Masjid');
+  assert.equal(body.data.rows.length, 3);
+  assert.ok(body.data.rows[0].date, 'rows survive validateAndFixRows');
+});
+
+test('extract: unparseable AI response returns a clear error', async () => {
+  installFetch({ 'api.anthropic.com': () => j({ content: [{ text: 'not json at all' }] }) });
+  const res = await worker.fetch(extractRequest(), env);
+  assert.equal(res.status, 502);
+  const body = await res.json();
+  assert.match(body.error, /parse/i);
+});
+
+// ---- /api/submit ----
+
+test('submit: happy path commits CSV + config + index and returns the slug', async () => {
+  const { rows, year } = sampleRows();
+  const res = await worker.fetch(submitRequest({ data: { mosque_name: 'Test Masjid', rows, year } }), env);
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.success, true);
+  assert.equal(body.slug, 'test_masjid');
+  assert.equal(body.pending, true);
+
+  // The single commit's tree must contain the CSV, config and both indexes
+  const treeCall = fetchCalls.find(c => c.method === 'POST' && c.url.endsWith('/git/trees'));
+  assert.ok(treeCall, 'expected a git tree to be created');
+  const paths = JSON.parse(treeCall.body).tree.map(t => t.path);
+  for (const p of ['data/test_masjid.csv', 'data/mosques/test_masjid.json', 'data/mosques/index.json', 'data/mosques/index-slim.json']) {
+    assert.ok(paths.includes(p), `tree missing ${p}`);
+  }
+  // Commit landed and a review notification was raised
+  assert.ok(fetchCalls.some(c => c.method === 'PATCH' && c.url.includes('/git/refs/heads/main')));
+  assert.ok(fetchCalls.some(c => c.method === 'POST' && c.url.endsWith('/issues')));
+  // Quota consumed once
+  assert.equal(env.RATE_LIMITS.json('submit:1.2.3.4').count, 1);
+});
+
+test('submit: outdated timetable is rejected and does not consume quota', async () => {
+  const { rows, year } = pastRows();
+  const res = await worker.fetch(submitRequest({ data: { mosque_name: 'Test Masjid', rows, year } }), env);
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.match(body.error, /outdated/i);
+  assert.equal(env.RATE_LIMITS.store.size, 0);
+});
+
+test('submit: likely duplicate returns 409 warning and does not consume quota', async () => {
+  const existing = [{ display_name: 'Test Masjid', slug: 'existing', phone: '0121 111 2222', csv: 'existing.csv' }];
+  installFetch({
+    'contents/data/mosques/index.json': () => j({ content: btoa(JSON.stringify(existing)), sha: 'idxsha' }),
+  });
+  const { rows, year } = sampleRows();
+  const res = await worker.fetch(submitRequest({
+    data: { mosque_name: 'Test Masjid', phone: '01211112222', rows, year },
+  }), env);
+  assert.equal(res.status, 409);
+  const body = await res.json();
+  assert.equal(body.duplicate_warning, true);
+  assert.ok(body.matches.length >= 1);
+  assert.equal(env.RATE_LIMITS.store.size, 0);
+});
+
+test('submit: missing masjid name is rejected', async () => {
+  const { rows, year } = sampleRows();
+  const res = await worker.fetch(submitRequest({ data: { mosque_name: '', rows, year } }), env);
+  assert.equal(res.status, 400);
+});
+
+// ---- /api/update ----
+
+test('update: happy path merges the CSV and commits', async () => {
+  installFetch(updateOverrides());
+  const { rows, year } = sampleRows();
+  const res = await worker.fetch(updateRequest({
+    slug: 'testmasjid',
+    data: { mosque_name: 'Test Masjid', rows, year },
+  }), env);
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.success, true);
+  assert.match(body.message, /Test Masjid/);
+
+  const treeCall = fetchCalls.find(c => c.method === 'POST' && c.url.endsWith('/git/trees'));
+  assert.ok(treeCall, 'expected a git tree to be created');
+  const paths = JSON.parse(treeCall.body).tree.map(t => t.path);
+  assert.ok(paths.includes('data/testmasjid.csv'), 'updated CSV committed');
+  assert.ok(paths.includes('data/mosques/testmasjid.json'), 'updated config committed');
+  assert.equal(env.RATE_LIMITS.json('update:1.2.3.4').count, 1);
+});
+
+test('update: wrong timetable (name mismatch) is rejected without consuming quota', async () => {
+  installFetch(updateOverrides());
+  const { rows, year } = sampleRows();
+  const res = await worker.fetch(updateRequest({
+    slug: 'testmasjid',
+    data: { mosque_name: 'Completely Different Islamic Centre Somewhere', rows, year },
+  }), env);
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.match(body.error, /doesn't appear to be the timetable/);
+  assert.equal(env.RATE_LIMITS.store.size, 0);
+});
+
+test('update: unknown slug returns 404 Masjid not found', async () => {
+  const { rows, year } = sampleRows();
+  const res = await worker.fetch(updateRequest({
+    slug: 'no_such_masjid',
+    data: { mosque_name: 'Test Masjid', rows, year },
+  }), env);
+  assert.equal(res.status, 404);
+  const body = await res.json();
+  assert.match(body.error, /not found/i);
+});


### PR DESCRIPTION
## Problem

A user was blocked by the extraction rate limit despite not having extracted anything in months. Investigation showed three compounding issues in the KV rate limiter:

1. **Failed attempts consumed quota.** The counter incremented at the top of each handler, before Turnstile verification and form validation. Attempts that failed (expired Turnstile token, bad form data, oversized file) silently burned the shared bucket while leaving no trace in the extraction-attempt issue log. This is how a household's bucket filled invisibly: failed wifi attempts counted, then the successes happened on mobile data under a different IP.
2. **IPv6 made the limit both leaky and unfair.** Buckets were keyed on the full /128 address, which rotates per device (privacy extensions), so IPv6 users effectively got unlimited fresh buckets while NAT'd IPv4 households shared one.
3. **Misleading error message.** "Try again next month" when the window is actually rolling 30 days from a request the user may never have made themselves.

## Changes

- Split `isRateLimited` into a read-only `checkRateLimit` gate plus a `recordRateLimitUse` step that runs only after validation passes (for extract: after Turnstile, file checks and prompt load; for submit: after the duplicate check, so the confirm round-trip doesn't double-count; for update: after name match and date validation)
- Bucket IPv6 by /64 prefix so one connection shares one bucket, matching NAT'd IPv4 behaviour
- Raise `extract` and `update` to 10 per rolling 30 days (they're consumed in pairs by the update flow); `submit` stays at 5 since it creates new masjid files in the repo
- 429 message now states the actual limit and the date the window resets

Sitewide extraction volume is 3 to 6 per month, so the raised per-connection cap is still a tight abuse ceiling (roughly a dollar of API spend if maxed).

## Tests

New `tests/worker.test.mjs` (16 tests, zero dependencies, Node's built-in runner) drives the real `_worker.js` fetch handler with a fake env (in-memory KV, stubbed GitHub/Claude/Turnstile/Nominatim) and covers the whole upload surface:

- extract: happy path, name override, unparseable AI response, missing file
- rate limiting: 429 at the cap with honest message, quota consumed only on validated attempts, Turnstile failure doesn't count, IPv6 /64 bucket sharing, admin bypass
- submit: full commit tree contents (CSV + config + both indexes), stale-date rejection, duplicate detection 409, missing name
- update: CSV merge commit, wrong-timetable name mismatch, unknown slug 404

New `.github/workflows/worker-tests.yml` runs the suite on every PR touching `_worker.js`, `tests/` or `prompts/extraction.txt`. Run locally with `node --test tests/worker.test.mjs`.

## Deploy effect

Existing KV entries are compatible (same key format for IPv4, same `{count, start}` shape). The currently blocked bucket sits at count 5, which is under the new max of 10, so deploying this unblocks the affected user with no manual KV surgery. Old full-address IPv6 keys become orphaned and expire naturally.